### PR TITLE
Add built-in full text search

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,161 @@
+package search
+
+import (
+	"log/slog"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
+)
+
+var (
+	index    = make(map[string]map[string]struct{})
+	conveyor = make(chan indexOperation)
+)
+
+type indexOperation interface{ apply() }
+
+type indexEdit struct {
+	name      string
+	oldTokens []string
+	newTokens []string
+}
+
+type indexDelete struct {
+	name   string
+	tokens []string
+}
+
+type indexRename struct {
+	oldName string
+	newName string
+	tokens  []string
+}
+
+func RunConveyor() {
+	defer close(conveyor)
+	for op := range conveyor {
+		op.apply()
+	}
+}
+
+func Index() {
+	for h := range hyphae.FilterHyphaeWithText(hyphae.YieldExistingHyphae()) {
+		text, err := hyphae.FetchMycomarkupFile(h)
+		if err != nil {
+			slog.Error("failed to read hypha text", "err", err, "hypha", h.CanonicalName())
+			continue
+		}
+		addTokens(h.CanonicalName(), tokenise(text))
+	}
+}
+
+func Search(query string) []string {
+	tokens := tokenise(query)
+	if len(tokens) == 0 {
+		return nil
+	}
+	sets := make([]map[string]struct{}, 0, len(tokens))
+	for _, t := range tokens {
+		if set, ok := index[t]; ok {
+			sets = append(sets, set)
+		} else {
+			return nil
+		}
+	}
+	result := make(map[string]struct{})
+	for h := range sets[0] {
+		result[h] = struct{}{}
+	}
+	for _, set := range sets[1:] {
+		for h := range result {
+			if _, ok := set[h]; !ok {
+				delete(result, h)
+			}
+		}
+	}
+	out := make(chan string)
+	sorted := hyphae.PathographicSort(out)
+	go func() {
+		for h := range result {
+			out <- h
+		}
+		close(out)
+	}()
+	var res []string
+	for h := range sorted {
+		res = append(res, h)
+	}
+	return res
+}
+
+func UpdateAfterEdit(h hyphae.Hypha, oldText string) {
+	newText, _ := hyphae.FetchMycomarkupFile(h)
+	conveyor <- indexEdit{h.CanonicalName(), tokenise(oldText), tokenise(newText)}
+}
+
+func UpdateAfterDelete(h hyphae.Hypha, oldText string) {
+	conveyor <- indexDelete{h.CanonicalName(), tokenise(oldText)}
+}
+
+func UpdateAfterRename(h hyphae.Hypha, oldName string) {
+	text, _ := hyphae.FetchMycomarkupFile(h)
+	conveyor <- indexRename{oldName, h.CanonicalName(), tokenise(text)}
+}
+
+func addTokens(name string, tokens []string) {
+	for _, t := range tokens {
+		set, ok := index[t]
+		if !ok {
+			set = make(map[string]struct{})
+			index[t] = set
+		}
+		set[name] = struct{}{}
+	}
+}
+
+func removeTokens(name string, tokens []string) {
+	for _, t := range tokens {
+		if set, ok := index[t]; ok {
+			delete(set, name)
+			if len(set) == 0 {
+				delete(index, t)
+			}
+		}
+	}
+}
+
+func tokenise(text string) []string {
+	text = strings.ToLower(text)
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	uniq := make(map[string]struct{})
+	var res []string
+	for _, f := range fields {
+		if f == "" {
+			continue
+		}
+		if _, ok := uniq[f]; !ok {
+			uniq[f] = struct{}{}
+			res = append(res, f)
+		}
+	}
+	sort.Strings(res)
+	return res
+}
+
+func (op indexEdit) apply() {
+	removeTokens(op.name, op.oldTokens)
+	addTokens(op.name, op.newTokens)
+}
+
+func (op indexDelete) apply() {
+	removeTokens(op.name, op.tokens)
+}
+
+func (op indexRename) apply() {
+	removeTokens(op.oldName, op.tokens)
+	addTokens(op.newName, op.tokens)
+}

--- a/internal/shroom/delete.go
+++ b/internal/shroom/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/internal/backlinks"
 	"github.com/bouncepaw/mycorrhiza/internal/categories"
 	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
+	"github.com/bouncepaw/mycorrhiza/internal/search"
 	"github.com/bouncepaw/mycorrhiza/internal/user"
 )
 
@@ -32,6 +33,7 @@ func Delete(u *user.User, h hyphae.ExistingHypha) error {
 		return hop.Errs[0]
 	}
 	backlinks.UpdateBacklinksAfterDelete(h, originalText)
+	search.UpdateAfterDelete(h, originalText)
 	categories.RemoveHyphaFromAllCategories(h.CanonicalName())
 	hyphae.DeleteHypha(h)
 	return nil

--- a/internal/shroom/rename.go
+++ b/internal/shroom/rename.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/internal/cfg"
 	"github.com/bouncepaw/mycorrhiza/internal/files"
 	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
+	"github.com/bouncepaw/mycorrhiza/internal/search"
 	"github.com/bouncepaw/mycorrhiza/internal/user"
 	"github.com/bouncepaw/mycorrhiza/util"
 )
@@ -83,6 +84,7 @@ func Rename(oldHypha hyphae.ExistingHypha, newName string, recursive bool, leave
 		)
 		hyphae.RenameHyphaTo(h, newName, replaceName)
 		backlinks.UpdateBacklinksAfterRename(h, oldName)
+		search.UpdateAfterRename(h, oldName)
 		categories.RenameHyphaInAllCategories(oldName, newName)
 		if leaveRedirections {
 			if err := leaveRedirection(oldName, newName, hop); err != nil {
@@ -112,6 +114,7 @@ func leaveRedirection(oldName, newName string, hop *history.Op) error {
 		hyphae.Insert(h)
 		categories.AddHyphaToCategory(oldName, cfg.RedirectionCategory)
 		defer backlinks.UpdateBacklinksAfterEdit(h, "")
+		defer search.UpdateAfterEdit(h, "")
 		return writeTextToDisk(h, []byte(text), hop)
 	default:
 		return errors.New("invalid state for hypha " + oldName + " renamed to " + newName)

--- a/internal/shroom/upload.go
+++ b/internal/shroom/upload.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/internal/files"
 	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
 	"github.com/bouncepaw/mycorrhiza/internal/mimetype"
+	"github.com/bouncepaw/mycorrhiza/internal/search"
 	"github.com/bouncepaw/mycorrhiza/internal/user"
 )
 
@@ -92,6 +93,7 @@ func UploadText(h hyphae.Hypha, data []byte, userMessage string, u *user.User) e
 
 		hyphae.Insert(H)
 		backlinks.UpdateBacklinksAfterEdit(H, "")
+		search.UpdateAfterEdit(H, "")
 	case *hyphae.MediaHypha:
 		// TODO: that []byte(...) part should be removed
 		if bytes.Equal(data, []byte(oldText)) {
@@ -107,6 +109,7 @@ func UploadText(h hyphae.Hypha, data []byte, userMessage string, u *user.User) e
 		}
 
 		backlinks.UpdateBacklinksAfterEdit(h, oldText)
+		search.UpdateAfterEdit(h, oldText)
 	case *hyphae.TextualHypha:
 		oldText, err := hyphae.FetchMycomarkupFile(h)
 		if err != nil {
@@ -128,6 +131,7 @@ func UploadText(h hyphae.Hypha, data []byte, userMessage string, u *user.User) e
 		}
 
 		backlinks.UpdateBacklinksAfterEdit(h, oldText)
+		search.UpdateAfterEdit(h, oldText)
 	}
 
 	hop.Apply()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/internal/files"
 	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
 	"github.com/bouncepaw/mycorrhiza/internal/migration"
+	"github.com/bouncepaw/mycorrhiza/internal/search"
 	"github.com/bouncepaw/mycorrhiza/internal/shroom"
 	"github.com/bouncepaw/mycorrhiza/internal/user"
 	"github.com/bouncepaw/mycorrhiza/internal/version"
@@ -51,7 +52,9 @@ func main() {
 	viewutil.Init()
 	hyphae.Index(files.HyphaeDir())
 	backlinks.IndexBacklinks()
+	search.Index()
 	go backlinks.RunBacklinksConveyor()
+	go search.RunConveyor()
 	user.InitUserDatabase()
 	if err := history.Start(); err != nil {
 		os.Exit(1)

--- a/misc/handlers.go
+++ b/misc/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bouncepaw/mycorrhiza/internal/cfg"
 	"github.com/bouncepaw/mycorrhiza/internal/files"
 	"github.com/bouncepaw/mycorrhiza/internal/hyphae"
+	"github.com/bouncepaw/mycorrhiza/internal/search"
 	"github.com/bouncepaw/mycorrhiza/internal/shroom"
 	"github.com/bouncepaw/mycorrhiza/internal/user"
 	"github.com/bouncepaw/mycorrhiza/l18n"
@@ -40,6 +41,7 @@ func InitHandlers(rtr *mux.Router) {
 	rtr.HandleFunc("/random", handlerRandom)
 	rtr.HandleFunc("/about", handlerAbout)
 	rtr.HandleFunc("/title-search/", handlerTitleSearch)
+	rtr.HandleFunc("/search/", handlerFullSearch)
 	initViews()
 }
 
@@ -183,4 +185,13 @@ func handlerTitleSearch(w http.ResponseWriter, rq *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	viewTitleSearch(viewutil.MetaFrom(w, rq), query, hyphaName, !nameFree, results)
+}
+
+func handlerFullSearch(w http.ResponseWriter, rq *http.Request) {
+	util.PrepareRq(rq)
+	_ = rq.ParseForm()
+	query := rq.FormValue("q")
+	results := search.Search(query)
+	w.WriteHeader(http.StatusOK)
+	viewFullSearch(viewutil.MetaFrom(w, rq), query, results)
 }

--- a/misc/view_full_search.html
+++ b/misc/view_full_search.html
@@ -1,0 +1,18 @@
+{{define "search:"}}Search: {{.}}{{end}}
+{{define "title"}}{{template "search:" .Query}}{{end}}
+{{define "body"}}
+<main class="main-width">
+        <h1>{{block "search results for" .Query}}Search results for ‘{{.}}’{{end}}</h1>
+        {{if len .Results}}
+                <ol>
+        {{range .Results}}
+                        <li>
+                                <a class="wikilink" href="/hypha/{{.}}">{{beautifulName .}}</a>
+                        </li>
+        {{end}}
+                </ol>
+    {{else}}
+            <p>{{block "search no results" .}}No results{{end}}</p>
+    {{end}}
+</main>
+{{end}}

--- a/misc/view_title_search.html
+++ b/misc/view_title_search.html
@@ -3,10 +3,11 @@
 {{define "body"}}
 <main class="main-width">
 	<h1>{{block "search results for" .Query}}Search results for ‘{{.}}’{{end}}</h1>
-	{{if .MatchedHyphaName}}
-		<p>{{block "go to hypha" .}}Go to hypha <a class="wikilink{{if .HasExactMatch | not}} wikilink_new{{end}}" href="/hypha/{{.MatchedHyphaName}}">{{beautifulName .MatchedHyphaName}}</a>.{{end}}</p>
-	{{end}}
-	{{if len .Results}}
+        {{if .MatchedHyphaName}}
+                <p>{{block "go to hypha" .}}Go to hypha <a class="wikilink{{if .HasExactMatch | not}} wikilink_new{{end}}" href="/hypha/{{.MatchedHyphaName}}">{{beautifulName .MatchedHyphaName}}</a>.{{end}}</p>
+        {{end}}
+        <p><a href="/search/?q={{.Query}}">{{block "search text" .}}Search in text{{end}}</a></p>
+        {{if len .Results}}
 		<ol>
         {{range .Results}}
 			<li>

--- a/misc/views.go
+++ b/misc/views.go
@@ -11,6 +11,7 @@ var (
 	//go:embed *html
 	fs                          embed.FS
 	chainList, chainTitleSearch viewutil.Chain
+	chainFullSearch             viewutil.Chain
 	ruTranslation               = `
 {{define "list of hyphae"}}Список гиф{{end}}
 {{define "search:"}}Поиск: {{.}}{{end}}
@@ -18,12 +19,14 @@ var (
 {{define "search no results"}}Ничего не найдено.{{end}}
 {{define "x total"}}{{.}} всего.{{end}}
 {{define "go to hypha"}}Перейти к гифе <a class="wikilink{{if .HasExactMatch | not}} wikilink_new{{end}}" href="/hypha/{{.MatchedHyphaName}}">{{beautifulName .MatchedHyphaName}}</a>.{{end}}
+{{define "search text"}}Искать в тексте{{end}}
 `
 )
 
 func initViews() {
 	chainList = viewutil.CopyEnRuWith(fs, "view_list.html", ruTranslation)
 	chainTitleSearch = viewutil.CopyEnRuWith(fs, "view_title_search.html", ruTranslation)
+	chainFullSearch = viewutil.CopyEnRuWith(fs, "view_full_search.html", ruTranslation)
 }
 
 type listDatum struct {
@@ -60,5 +63,19 @@ func viewTitleSearch(meta viewutil.Meta, query string, hyphaName string, hasExac
 		Results:          results,
 		MatchedHyphaName: hyphaName,
 		HasExactMatch:    hasExactMatch,
+	})
+}
+
+type fullSearchData struct {
+	*viewutil.BaseData
+	Query   string
+	Results []string
+}
+
+func viewFullSearch(meta viewutil.Meta, query string, results []string) {
+	viewutil.ExecutePage(meta, chainFullSearch, fullSearchData{
+		BaseData: &viewutil.BaseData{},
+		Query:    query,
+		Results:  results,
 	})
 }

--- a/web/newtmpl/newtmpl.go
+++ b/web/newtmpl/newtmpl.go
@@ -77,6 +77,7 @@ func NewPage(fs embed.FS, russianTranslation map[string]string, tmpls ...string)
 	}
 
 	russianTranslation["search by title"] = "Поиск по названию"
+	russianTranslation["search text"] = "Искать в тексте"
 	russianTranslation["login"] = "Войти"
 	russianTranslation["register"] = "Регистрация"
 	russianTranslation["cancel"] = "Отмена"

--- a/web/viewutil/viewutil.go
+++ b/web/viewutil/viewutil.go
@@ -23,6 +23,7 @@ var (
 
 const ruText = `
 {{define "search by title"}}Поиск по названию{{end}}
+{{define "search text"}}Искать в тексте{{end}}
 {{define "login"}}Войти{{end}}
 {{define "register"}}Регистрация{{end}}
 {{define "confirm"}}Подтвердить{{end}}


### PR DESCRIPTION
## Summary
- implement full text search indexing
- update CLI to build and update index
- expose `/search/` endpoint with results page
- link from title search page to full text search
- keep Russian translations up to date

## Testing
- `go vet ./...` *(fails: header_links.go struct literal uses unkeyed fields)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8bd7f3c832fb8258e6b07e49d7e